### PR TITLE
Firewall improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,3 +9,6 @@
 
 2016-06-26 Release 1.2.1
 - Minor fix in README
+
+2018-08-07 Release 1.3.0
+- Firewall policy updates (new firewall rule properties: port, action, description)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem '1and1', '>= 1.1'
+gem '1and1', '>= 1.3'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 4.0']
 gem 'metadata-json-lint'

--- a/examples/firewall.pp
+++ b/examples/firewall.pp
@@ -3,9 +3,9 @@ oneandone_firewall { 'puppet-test-policy':
   description => 'Test policy desc',
   rules       => [
     {
-      port_from => 80,
-      port_to   => 80,
+      port => '80-83',
       protocol  => 'TCP',
+      description => 'Testing firewall improvements with puppet.',
       source    => '0.0.0.0'
     },
     {

--- a/lib/puppet/provider/oneandone_firewall/v1.rb
+++ b/lib/puppet/provider/oneandone_firewall/v1.rb
@@ -49,12 +49,16 @@ Puppet::Type.type(:oneandone_firewall).provide(:v1) do
   def self.rules_from_instance(instance)
     rules = []
     instance['rules'].each do |rule|
-      rules.push(
-        protocol: rule['protocol'],
-        port_from: rule['port_from'],
-        port_to: rule['port_to'],
-        source: rule['source']
-      )
+      r = {
+          protocol: rule['protocol'],
+          port_from: rule['port_from'].nil? ? nil : rule['port_from'],
+          port_to: rule['port_to'].nil? ? nil : rule['port_to'],
+          source: rule['source'],
+          description: rule['description'].nil? ? nil : rule['description'],
+          action: rule['action'].nil? ? nil : rule['action'],
+          port: rule['port'].nil? ? nil : rule['port']
+      }
+      rules.push(r.select{|k,v| !v.nil?})
     end
     rules
   end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "oneandone-puppet1and1",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Nurfet Becirevic (stackpointcloud.com)",
   "summary": "Manage 1&1 cloud servers with Puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
Updates for 1&1 Cloud Server API [release 1.10](https://cloudpanel-api.1and1.com/documentation/v1/en/api/change_log.html).

Tested using the following manifest:

```
oneandone_firewall { 'puppet-test-policy':
  ensure      => present,
  description => 'Test policy desc',
  rules       => [
    {
      port => '80-83',
      protocol  => 'TCP',
      description => 'Testing firewall improvements with puppet.',
      source    => '0.0.0.0'
    },
    {
      port_from => 8080,
      port_to   => 8080,
      protocol  => 'TCP/UDP',
      source    => '0.0.0.0'
    }
  ]
}
```